### PR TITLE
Adding link to js-level-pull-blob-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A test suite and interface that can be used to implement streaming file ([blob](
 
 - [fs-pull-blob-store](https://github.com/ipfs/js-fs-pull-blob-store)
 - [idb-pull-blob-store](https://github.com/ipfs/js-idb-pull-blob-store)
+- [level-pull-blob-store](https://github.com/ipfs/js-level-pull-blob-store)
 
 ## Table of Contents
 


### PR DESCRIPTION
@dignifiedquire I found a way around the issue I was having with the tests.  Here is the link to the js-level-pull-blob-store.  Thanks for your help.