### PR TITLE
Setting timeout to 1 second

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A test suite and interface that can be used to implement streaming file ([blob](
 
 - [fs-pull-blob-store](https://github.com/ipfs/js-fs-pull-blob-store)
 - [idb-pull-blob-store](https://github.com/ipfs/js-idb-pull-blob-store)
+- [level-pull-blob-store](https://github.com/ipfs/js-level-pull-blob-store)
 
 ## Table of Contents
 

--- a/src/read-write.js
+++ b/src/read-write.js
@@ -74,7 +74,7 @@ module.exports = (common) => {
         )
 
         // give it some time to finish the write
-        setTimeout(validateWrite, 200)
+        setTimeout(validateWrite, 1000)
         function validateWrite () {
           pull(
             store.read('hi'),


### PR DESCRIPTION
The setTimeout() function in the read-write.js file was set to 200 milliseconds.  My tests were failing on a slower maching so I set the timeout to 1 second to give time for the write operation to finish.